### PR TITLE
Update image block visual preferences

### DIFF
--- a/docs/field-types/field-type-content-blocks.md
+++ b/docs/field-types/field-type-content-blocks.md
@@ -41,7 +41,7 @@ Probably a custom block.
 
 * [Image](field-type-image.md)
 * Caption (defaults to the image asset caption, but can be overwritten)
-* Visual Preference (one of `standard`, `left`, `right`, `prominent`)
+* Visual Preference (one of `discreet`, `standard`, `prominent`)
 
 ----
 
@@ -116,4 +116,3 @@ This is a block that can define a geographical position. It is basically just a 
 
 * NE Coordinate (expressed as LatLng)
 * SW Coordinate (expressed as LatLng)
-


### PR DESCRIPTION
New visual preferences for image block:

- Standard (default)
- Prominent
- Full

Can't find a better option than "full", even though it very much implies how it's rendered (it most probably will render as big as it can – bleeding to the edges of the viewport"). Perhaps it's ok, or can you come up with a better, more "rendering neutral" word @martinlissmyr ?