### PR TITLE
Content item title and content item teaser heading

### DIFF
--- a/_data/configuration-content-teaser-preferences-fields.yaml
+++ b/_data/configuration-content-teaser-preferences-fields.yaml
@@ -13,7 +13,3 @@
 - field: "Context Label Position"
   required: "Yes"
   comment: "Where should the context label be rendered? Either \"above_heading\" or \"below_heading\"."
-- field: "Contributor In Opinion Piece Heading"
-  required: "Yes"
-  field_type: "boolean"
-  comment: "Should title in opinion piece heading be prepended by the contributor? Only applicable when there is 1 contributor."

--- a/_data/configuration-content-teaser-preferences-fields.yaml
+++ b/_data/configuration-content-teaser-preferences-fields.yaml
@@ -13,3 +13,7 @@
 - field: "Context Label Position"
   required: "Yes"
   comment: "Where should the context label be rendered? Either \"above_heading\" or \"below_heading\"."
+- field: "Contributor In Opinion Piece Heading"
+  required: "Yes"
+  field_type: "boolean"
+  comment: "Should title in opinion piece heading be prepended by the contributor? Only applicable when there is 1 contributor."

--- a/docs/configuration/content-item-teaser-preferences.md
+++ b/docs/configuration/content-item-teaser-preferences.md
@@ -9,6 +9,6 @@ has_children: true
 
 # Content Item Teaser Preferences
 
-It is possible to specify teaser display preferences for each Content Variant. For each variant it is possible to define:
+It is possible to specify teaser display preferences for each Content Variant. Preferences for [Content Item](../configuration/content-item-preferences) are inherited. For each variant it is possible to define:
 
-{% include fields-table.md definition="configuration-content-teaser-preferences-fields" %}
+{% include fields-table.md parent_definition="configuration-content-preferences-fields" definition="configuration-content-teaser-preferences-fields" %}

--- a/docs/information-design-templates/components-and-containers-teaser.md
+++ b/docs/information-design-templates/components-and-containers-teaser.md
@@ -20,6 +20,8 @@ A Content Item may have [specific promotion data](../data-models/content-item.md
 ## Heading
 The platform will use the Promotion Title or fallback to the Content Item Title.
 
+Heading is prefixed with contributor if the content variant is ["Opinion Piece"](../data-models/content-type-article.html#content-variants), there is 1 contributor and ["Contributor In Opinion Piece Heading"](../configuration/content-item-preferences) configuration is set to true.
+
 ## Image
 The platform will use the Promotion Image or fallback to the main image of the Content Item.
 

--- a/docs/information-design-templates/content-item.md
+++ b/docs/information-design-templates/content-item.md
@@ -45,9 +45,18 @@ A Content Item may have a set of "context labels" above the title. What these la
 
 ----
 
-## Title & Lead
+## Title
 
-The title and lead on the Content Item Page will always be based on the main Title and Lead fields. 
+The title on the Content Item Page will always be based on the main Title field.
+Promotion & Indexing Data will never be used in this context.
+
+Title is prefixed with contributor if the content variant is ["Opinion Piece"](../data-models/content-type-article.html#content-variants), there is 1 contributor and ["Contributor In Opinion Piece Heading"](../configuration/content-item-preferences) configuration is set to true.
+
+----
+
+## Lead
+
+The lead on the Content Item Page will always be based on the main Lead field.
 Promotion & Indexing Data will never be used in this context.
 
 ----


### PR DESCRIPTION
@martinlissmyr after having a look, I don't think it make sense to merge configuration for content item and content item teaser.

Specifying some kind of config inheritance could perhaps be the way to go, but I went for duplication for now. Hope that's fine.